### PR TITLE
further development to allow the DVI smartcontrol webpage to be created within HA

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,9 +1,21 @@
+
+# Loads default set of integrations. Do not remove.
+default_config:
+
+# Text to speech
+tts:
+  - platform: google_translate
+
+automation: !include automations.yaml
+script: !include scripts.yaml
+scene: !include scenes.yaml
+    
 rest:
   - authentication: basic
     resource: https://ws.dvienergi.com/API/
     method: POST
     scan_interval: 60
-    payload: '{"usermail": "YOUR@EMAIL.COM",	"userpassword": "YOURPASSWORD",	"fabnr":YOURFABNR,	"get":{"bestgreen":0,"sensor":1,"relay":0,"timer":0,"userSettings":1}}'
+    payload: '{"usermail": "your@email",	"userpassword": "your password",	"fabnr":xyzxyzx,	"get":{"bestgreen":0,"sensor":1,"relay":1,"timer":0,"userSettings":1}}'
     sensor:
       - name: "Dvi Heatpump Sensors"
         json_attributes_path: $.output.sensor
@@ -18,8 +30,6 @@ rest:
           - Outsidetemperature
           - Highpressure
           - Lowpressure
-          - Powermeter.kW
-          - Powermeter.kWh
       - name: "Dvi Heatpump Settings"
         json_attributes_path: $.output.userSettings
         value_template: "OK"
@@ -51,109 +61,99 @@ rest:
           - Relay14
 
 template:
-  - sensor:
-      - name: "Heatpump Power consumption"
-        unit_of_measurement: "kW"
-        device_class: power
-        state_class: measurement
-        state: "{{ state_attr('sensor.dvi_heatpump_sensors','Powermeter.kW') }}"
-  - sensor:
-      - name: "Heatpump Power meter"
-        unit_of_measurement: "kWh"
-        device_class: energy
-        state_class: total_increasing
-        state: "{{ state_attr('sensor.dvi_heatpump_sensors','Powermeter.kWh') }}"
-  - sensor:
-      - name: "Heatpump Outside temp"
-        unit_of_measurement: "°C"
-        device_class: temperature
-        state: "{{ state_attr('sensor.dvi_heatpump_sensors','Outsidetemperature') }}"
-        icon: "mdi:tree"
-  - sensor:
-      - name: "Heatpump CV forward"
-        device_class: temperature
-        state: "{{ state_attr('sensor.dvi_heatpump_sensors','Centralheating.Forward') }}"
-        unit_of_measurement: "°C"
-  - sensor:
-      - name: "Heatpump CV return"
-        device_class: temperature
-        state: "{{ state_attr('sensor.dvi_heatpump_sensors','Centralheating.Return') }}"
-        unit_of_measurement: "°C"
-  - sensor:
-      - name: "Heatpump storage tank"
-        device_class: temperature
-        state: "{{ state_attr('sensor.dvi_heatpump_sensors','Storagetank.Centralheating') }}"
-        unit_of_measurement: "°C"
-  - sensor:
-      - name: "Heatpump Hotwater"
-        device_class: temperature
-        state: "{{ state_attr('sensor.dvi_heatpump_sensors','Storagetank.Hotwater') }}"
-        unit_of_measurement: "°C"
-        icon: "mdi:water-pump"
-  - sensor:
-      - name: "Heatpump CV Curve"
-        state: "{{ state_attr('sensor.dvi_heatpump_settings','Centralheat.Curve') }}"
-  - sensor:
-      - name: "Heatpump CV CurveTemp"
-        device_class: temperature
-        unit_of_measurement: "°C"
-        state: "{{ state_attr('sensor.dvi_heatpump_settings','Centralheat.CurveTemp') }}"
-  - sensor:
-      - name: "Heatpump Hotwater Target"
-        device_class: temperature
-        unit_of_measurement: "°C"
-        state: "{{ state_attr('sensor.dvi_heatpump_settings','Hotwater.Temp') }}"
+  - sensor:      
+    - name: "Heatpump Outside temp"
+      unit_of_measurement: "°C"
+      device_class: temperature
+      state: "{{ state_attr('sensor.dvi_heatpump_sensors','Outsidetemperature') }}"
+      icon: "mdi:tree"
+
+    - name: "Heatpump CV forward"
+      device_class: temperature
+      state: "{{ state_attr('sensor.dvi_heatpump_sensors','Centralheating.Forward') }}"
+      unit_of_measurement: "°C"
+
+    - name: "Heatpump CV return"
+      device_class: temperature
+      state: "{{ state_attr('sensor.dvi_heatpump_sensors','Centralheating.Return') }}"
+      unit_of_measurement: "°C"
+      
+    - name: "Heatpump storage tank"
+      device_class: temperature
+      state: "{{ state_attr('sensor.dvi_heatpump_sensors','Storagetank.Centralheating') }}"
+      unit_of_measurement: "°C"
+
+    - name: "Heatpump Hotwater"
+      device_class: temperature
+      state: "{{ state_attr('sensor.dvi_heatpump_sensors','Storagetank.Hotwater') }}"
+      unit_of_measurement: "°C"
+      icon: "mdi:water-pump"
+
+    - name: "Heatpump CV Curve"
+      state: "{{ state_attr('sensor.dvi_heatpump_settings','Centralheat.Curve') }}"
+
+    - name: "Heatpump CV CurveTemp"
+      device_class: temperature
+      unit_of_measurement: "°C"
+      state: "{{ state_attr('sensor.dvi_heatpump_settings','Centralheat.CurveTemp') }}"
+
+    - name: "Heatpump Hotwater Target"
+      device_class: temperature
+      unit_of_measurement: "°C"
+      state: "{{ state_attr('sensor.dvi_heatpump_settings','Hotwater.Temp') }}"
+      
   - binary_sensor:
-      - name: "Heatpump Hotwater on"
-        state: "{{ state_attr('sensor.dvi_heatpump_settings','Hotwater.State') }}"
-  - binary_sensor:
-      - name: "Heatpump CV on"
-        state: "{{ state_attr('sensor.dvi_heatpump_settings','Centralheat.State') }}"
-  - binary_sensor:
-      - name: "Heatpump 4-vejs magnetventil for afrimning"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay1') }}"
-  - binary_sensor:
-      - name: "Heatpump Magnetventil for væskeindsprøjtning"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay2') }}"
-  - binary_sensor:
-      - name: "Heatpump 3-vejs shuntventil for centralvarme Åbne"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay3') }}"
-  - binary_sensor:
-      - name: "Heatpump 3-vejs shuntventil for centralvarme Lukke"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay4') }}"
-  - binary_sensor:
-      - name: "Heatpump Cirkulationspumpe centralvarme"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay5') }}"
-  - binary_sensor:
-      - name: "Heatpump Cirkulationspumpe solvarme"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay6') }}"
-  - binary_sensor:
-      - name: "Heatpump Sumalarm for fejl"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay7') }}"
-  - binary_sensor:
-      - name: "Heatpump 24 Ukendt"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay8') }}"
-  - binary_sensor:
-      - name: "Heatpump Softstarter for kompressor"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay9') }}"
-  - binary_sensor:
-      - name: "Heatpump 3-vejs motorventil for VV prioritering"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay10') }}"
-  - binary_sensor:
-      - name: "Heatpump GND "
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay11') }}"
-  - binary_sensor:
-      - name: "Heatpump 100 Relæ for el-patron"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay12') }}"
-  - binary_sensor:
-      - name: "Heatpump Cirkulationspumpe varm side"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay13') }}"
-  - binary_sensor:
-      - name: "Heatpump CV Evt. el-trasing af CV eller/og afløb"
-        state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay14') }}"
-  - binary_sensor:
-      - name: "Heatpump Kører"
-        state: "{{ state_attr('sensor.dvi_heatpump_sensors','Powermeter.kW') | float > 1 }}"
-  - binary_sensor:
-      - name: "Heatpump Hotwater Timer"
-        state: "{{ state_attr('sensor.dvi_heatpump_settings','Hotwater.Clock')}}"
+    - name: "Heatpump Hotwater on"
+      state: "{{ state_attr('sensor.dvi_heatpump_settings','Hotwater.State') }}"
+
+    - name: "Heatpump CV on"
+      state: "{{ state_attr('sensor.dvi_heatpump_settings','Centralheat.State') }}"
+
+    - name: "Heatpump 4-vejs magnetventil for afrimning"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay1') }}"
+
+    - name: "Heatpump Magnetventil for væskeindsprøjtning"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay2') }}"
+
+    - name: "Heatpump 3-vejs shuntventil for centralvarme Åbne"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay3') }}"
+
+    - name: "Heatpump 3-vejs shuntventil for centralvarme Lukke"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay4') }}"
+      
+    - name: "Heatpump Cirkulationspumpe centralvarme"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay5') }}"
+
+    - name: "Heatpump Cirkulationspumpe solvarme"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay6') }}"
+
+    - name: "Heatpump Sumalarm for fejl"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay7') }}"
+
+    - name: "Heatpump 24 Ukendt"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay8') }}"
+
+    - name: "Heatpump Softstarter for kompressor"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay9') }}"
+
+    - name: "Heatpump 3-vejs motorventil for VV prioritering"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay10') }}"
+
+    - name: "Heatpump GND "
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay11') }}"
+
+    - name: "Heatpump 100 Relæ for el-patron"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay12') }}"
+
+    - name: "Heatpump Cirkulationspumpe varm side"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay13') }}"
+
+    - name: "Heatpump CV Evt. el-trasing af CV eller/og afløb"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay14') }}"
+
+    - name: "Heatpump Kører"
+      state: "{{ state_attr('sensor.dvi_heatpump_relays','Relay9') }}"
+      
+    - name: "Heatpump Hotwater Timer"
+      state: "{{ state_attr('sensor.dvi_heatpump_settings','Hotwater.Clock')}}"
+      


### PR DESCRIPTION
Optimised the configuration.yaml file and fixed a few syntax errors. Heatpump run binary sensor now looking at softstarter relay as trigger. entries for energy meter removed as my heatpump is without. Energy meter entries can easily be added as per the main branch file.